### PR TITLE
Provide login details from application.properties file

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
-
+spring.security.user.name=abhi
+spring.security.user.password=abhi


### PR DESCRIPTION
We can provide the username and password as plain text in the application.properties file, instead of spring creates it for us.
This is not at all secured. 